### PR TITLE
fix: flush_handlers warning

### DIFF
--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -30,7 +30,6 @@
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
-  when: nginx_previous_restore_condition
 
 - name: Backup nginx
   ansible.builtin.include_tasks:


### PR DESCRIPTION
Fixed to following warning: `[WARNING]: flush_handlers task does not support when conditional`.