### PR TITLE
refactor: config restore procedure

### DIFF
--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -46,25 +46,33 @@
     file: vhosts_remove.ansible.yml
   when: nginx_vhosts_remove
 
-- name: Test nginx config
-  ansible.builtin.command:
-    cmd: nginx -t
-  register: nginx_test
-  ignore_errors: true
-  changed_when: false
-  no_log: true
-  become: true
-  when: nginx_backup_condition
+- name: Validate nginx config
+  block:
+    - name: Test nginx config
+      ansible.builtin.command:
+        cmd: nginx -t
+      changed_when: false
+      no_log: true
+      become: true
+      when: nginx_backup_condition
+  rescue:
+    - name: Restore nginx backup
+      ansible.builtin.include_tasks:
+        file: restore.ansible.yml
+      when: nginx_backup_condition
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers
+    - name: Invalid nginx config
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.stderr_lines }}"
 
-- name: Restore/delete nginx backup
-  ansible.builtin.include_tasks:
-    file: restore.ansible.yml
+- name: Delete backup
+  ansible.builtin.file:
+    path: "{{ nginx_backup_file }}"
+    state: absent
+  changed_when: false
+  become: true
   when: nginx_backup_condition
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
-
-- name: Invalid nginx config
-  ansible.builtin.fail:
-    msg: "{{ nginx_test.stderr_lines }}"
-  when: nginx_test.failed is defined and nginx_test.failed

--- a/tasks/restore.ansible.yml
+++ b/tasks/restore.ansible.yml
@@ -4,7 +4,6 @@
     path: "{{ nginx_path }}"
     state: absent
   become: true
-  when: not nginx_test is defined or nginx_test.failed
 
 - name: Restore backup
   ansible.builtin.unarchive:
@@ -12,7 +11,6 @@
     dest: "{{ nginx_path | dirname }}"
     remote_src: true
   become: true
-  when: not nginx_test is defined or nginx_test.failed
   notify: Reload nginx
 
 - name: Delete backup


### PR DESCRIPTION
Moved the restore logic into a `rescue` block.
This has the following benefits:

- Simplifies the internal logic of the role.
- Only displays the restore steps when they where executed, so they won't be shown as `skipped` anymore.